### PR TITLE
Add extra key called "NotificationId" and its value to capture in android main activity

### DIFF
--- a/src/Plugin.LocalNotifications.Android/LocalNotificationsImplementation.cs
+++ b/src/Plugin.LocalNotifications.Android/LocalNotificationsImplementation.cs
@@ -19,6 +19,11 @@ namespace Plugin.LocalNotifications
         public static int NotificationIconId { get; set; }
 
         /// <summary>
+        /// The key used to Intent's Extra.
+        /// </summary>
+        public const string LocalNotificationIntentKey = "NotificationId";
+
+        /// <summary>
         /// Show a local notification
         /// </summary>
         /// <param name="title">Title of the notification</param>
@@ -42,6 +47,7 @@ namespace Plugin.LocalNotifications
 
             var resultIntent = GetLauncherActivity();
             resultIntent.SetFlags(ActivityFlags.NewTask | ActivityFlags.ClearTask);
+            resultIntent.PutExtra(LocalNotificationIntentKey, id);
             var stackBuilder = Android.Support.V4.App.TaskStackBuilder.Create(Application.Context);
             stackBuilder.AddNextIntent(resultIntent);
             var resultPendingIntent =


### PR DESCRIPTION
### Changes proposed in this pull request:  

Add extra key called "NotificationId" and its value to possibility to override the method "OnNewIntent" and check this key and value in MainActivity.

```
public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
{
        protected override void OnCreate(Bundle bundle)
        {
            TabLayoutResource = Resource.Layout.Tabbar;
            ToolbarResource = Resource.Layout.Toolbar;
            base.OnCreate(bundle);
            global::Xamarin.Forms.Forms.Init(this, bundle);
            LoadApplication(new App());
            // Add the line above
            OnNewIntent(Intent);
        }
        protected override void OnNewIntent(Intent intent)
        {
            base.OnNewIntent(intent);
            if (intent.HasExtra(LocalNotificationsImplementation.LocalNotificationIntentKey))
            {
                // Do something with the notification Id...
            }
        }
}
```