### PR TITLE
Android notification visibility

### DIFF
--- a/src/Plugin.LocalNotifications.Android/LocalNotificationsImplementation.cs
+++ b/src/Plugin.LocalNotifications.Android/LocalNotificationsImplementation.cs
@@ -23,7 +23,8 @@ namespace Plugin.LocalNotifications
         public static int NotificationIconId { get; set; }
         public static NotificationImportance Importance { get; set; } = NotificationImportance.Default;
         public static int Priority { get; set; } = NotificationCompat.PriorityDefault;
-        public static long[] Vibrate { get; set; } = new long[0]; 
+        public static long[] Vibrate { get; set; } = new long[0];
+        public static NotificationVisibility Visibility { get; set; } = NotificationVisibility.Public;
 
         /// <summary>
         /// Show a local notification
@@ -41,7 +42,7 @@ namespace Plugin.LocalNotifications
             builder.SetAutoCancel(true);
             builder.SetPriority(Priority);
             builder.SetVibrate(Vibrate);
-
+            builder.SetVisibility(Visibility);
 
             if (NotificationIconId != 0)
             {


### PR DESCRIPTION
Fixes issue # . You cannot change notification Privacy for Notification 

With default Privacy it will show full notification on lock screen

### Changes proposed in this pull request:  
- set Visibility so notification is not viewable on lock screen or full notification is not visiable
- 
- 