### PR TITLE
Flag added for SDK31 intent creating compatibility

### DIFF
--- a/src/Plugin.LocalNotifications.Android/LocalNotificationsImplementation.cs
+++ b/src/Plugin.LocalNotifications.Android/LocalNotificationsImplementation.cs
@@ -59,7 +59,7 @@ namespace Plugin.LocalNotifications
             var stackBuilder = Android.Support.V4.App.TaskStackBuilder.Create(Application.Context);
             stackBuilder.AddNextIntent(resultIntent);
             var resultPendingIntent =
-                stackBuilder.GetPendingIntent(0, (int)PendingIntentFlags.UpdateCurrent);
+                stackBuilder.GetPendingIntent(0, (int)PendingIntentFlags.UpdateCurrent | (int)PendingIntentFlags.Immutable);
             builder.SetContentIntent(resultPendingIntent);
 
             _manager.Notify(id, builder.Build());


### PR DESCRIPTION
Fixes issue #74.  Android 12+ (version 31 and above) requires FLAG_IMMUTABLE or FLAG_MUTABLE.  

### Changes proposed in this pull request:  
- Adds flag FLAG_IMMUTABLE required on SDK 30+
